### PR TITLE
Inceptor chain should not be called for every eventHandler

### DIFF
--- a/eventbus-core/src/main/java/eu/tripledframework/eventbus/domain/annotation/EventHandler.java
+++ b/eventbus-core/src/main/java/eu/tripledframework/eventbus/domain/annotation/EventHandler.java
@@ -1,7 +1,11 @@
 package eu.tripledframework.eventbus.domain.annotation;
 
-
-import java.lang.annotation.*;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * Annotation to indicate that the annotated type is an EventHandler.
@@ -10,7 +14,7 @@ import java.lang.annotation.*;
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-// @Component
+@Inherited
 public @interface EventHandler {
 
 }

--- a/eventbus-core/src/main/java/eu/tripledframework/eventbus/domain/annotation/Handles.java
+++ b/eventbus-core/src/main/java/eu/tripledframework/eventbus/domain/annotation/Handles.java
@@ -8,6 +8,7 @@ import java.lang.annotation.*;
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Inherited
 public @interface Handles {
 
   Class<?> value();

--- a/eventbus-core/src/main/java/eu/tripledframework/eventbus/domain/interceptor/InterceptorChainFactory.java
+++ b/eventbus-core/src/main/java/eu/tripledframework/eventbus/domain/interceptor/InterceptorChainFactory.java
@@ -1,10 +1,12 @@
 package eu.tripledframework.eventbus.domain.interceptor;
 
-import eu.tripledframework.eventbus.domain.EventBusInterceptor;
-import eu.tripledframework.eventbus.domain.invoker.EventHandlerInvoker;
-
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
+
+import eu.tripledframework.eventbus.domain.EventBusInterceptor;
+import eu.tripledframework.eventbus.domain.InterceptorChain;
+import eu.tripledframework.eventbus.domain.invoker.EventHandlerInvoker;
 
 public class InterceptorChainFactory {
 
@@ -18,7 +20,7 @@ public class InterceptorChainFactory {
     this.interceptors = Collections.unmodifiableList(interceptors);
   }
 
-  public <ReturnType> SimpleInterceptorChain<ReturnType> createChain(Object event, EventHandlerInvoker invoker) {
+  public <ReturnType> InterceptorChain<ReturnType> createChain(Object event, Iterator<EventHandlerInvoker> invoker) {
     return new SimpleInterceptorChain<>(event, invoker, interceptors.iterator());
   }
 

--- a/eventbus-core/src/main/java/eu/tripledframework/eventbus/domain/invoker/EventHandlerInvokerRepository.java
+++ b/eventbus-core/src/main/java/eu/tripledframework/eventbus/domain/invoker/EventHandlerInvokerRepository.java
@@ -24,17 +24,16 @@ public class EventHandlerInvokerRepository {
     }
   }
 
-  public List<EventHandlerInvoker> findAllByEventTypeWithoutReturnType(Class<?> eventType) {
-    return eventHandlers.stream()
-        .filter(p -> p.handles(eventType) && !p.hasReturnType())
-        .collect(Collectors.toList());
-  }
-
-  public Optional<EventHandlerInvoker> findByEventTypeWithReturnType(Class<?> eventType) {
+  private Optional<EventHandlerInvoker> findByEventTypeWithReturnType(Class<?> eventType) {
     return eventHandlers.stream()
         .filter(input -> input.handles(eventType) && input.hasReturnType())
         .findFirst();
+  }
 
+  public List<EventHandlerInvoker> findAllByEventType(Class<?> eventType) {
+    return eventHandlers.stream()
+        .filter(p -> p.handles(eventType))
+        .collect(Collectors.toList());
   }
 }
 


### PR DESCRIPTION
Changed to logic so that the interceptor chain is executed once, and at
the end of the chain, call all eventhandlers. This remove to redundant
interceptor execution which depending on the interceptor, could produce
side effects.
