### PR TITLE
Changed signature of the publishing API.

### DIFF
--- a/eventbus-core/src/main/java/eu/tripledframework/eventbus/domain/EventPublisher.java
+++ b/eventbus-core/src/main/java/eu/tripledframework/eventbus/domain/EventPublisher.java
@@ -23,16 +23,9 @@ public interface EventPublisher {
    * Dispatches the given Event and invokes the given callback with either success or failure.
    *
    * @param event The event to publish.
-   * @param callback The callback to invoke upon completion.
    * @param <ReturnType>   The return type of the event handling.
+   * @return A future object to be used to retrieve the result.
    */
-  <ReturnType> void publish(Object event, Future<ReturnType> callback);
+  <ReturnType> Future<ReturnType> publish(Object event);
 
-  /**
-   * Dispatches an event without returning any feedback.
-   *
-   * @param event      The event to publish.
-   * @param <ReturnType> The return type of the event handling.
-   */
-  <ReturnType> void publish(Object event);
 }

--- a/eventbus-core/src/main/java/eu/tripledframework/eventbus/domain/callback/FutureEventCallback.java
+++ b/eventbus-core/src/main/java/eu/tripledframework/eventbus/domain/callback/FutureEventCallback.java
@@ -14,10 +14,6 @@ public class FutureEventCallback<ReturnType> implements EventCallback<ReturnType
   private Throwable exception;
   private CountDownLatch countDownLatch = new CountDownLatch(1);
 
-  public static <RT> Future<RT> forType(Class<RT> returnType) {
-    return new FutureEventCallback<>();
-  }
-
   @Override
   public void onSuccess(ReturnType result) {
     this.result = result;

--- a/eventbus-core/src/main/java/eu/tripledframework/eventbus/domain/synchronous/SynchronousEventBus.java
+++ b/eventbus-core/src/main/java/eu/tripledframework/eventbus/domain/synchronous/SynchronousEventBus.java
@@ -12,7 +12,7 @@ import eu.tripledframework.eventbus.domain.EventBusInterceptor;
 import eu.tripledframework.eventbus.domain.EventCallback;
 import eu.tripledframework.eventbus.domain.EventPublisher;
 import eu.tripledframework.eventbus.domain.EventSubscriber;
-import eu.tripledframework.eventbus.domain.callback.ExceptionThrowingEventCallback;
+import eu.tripledframework.eventbus.domain.callback.FutureEventCallback;
 import eu.tripledframework.eventbus.domain.dispatcher.EventDispatcher;
 import eu.tripledframework.eventbus.domain.interceptor.InterceptorChainFactory;
 import eu.tripledframework.eventbus.domain.invoker.EventHandlerInvoker;
@@ -63,17 +63,11 @@ public class SynchronousEventBus implements EventPublisher, EventSubscriber {
   // publish methods
 
   @Override
-  public void publish(Object message) {
-    publish(message, new ExceptionThrowingEventCallback<>());
-  }
+  public <ReturnType> Future<ReturnType> publish(Object event) {
+    FutureEventCallback<ReturnType> future = new FutureEventCallback<>();
+    publish(event, future);
 
-  @Override
-  public <ReturnType> void publish(Object event, Future<ReturnType> callback) {
-    if (callback instanceof EventCallback) {
-      publish(event, (EventCallback<ReturnType>) callback);
-    } else {
-      throw new IllegalArgumentException("The callback should be an instance of EventCallBack.");
-    }
+    return future;
   }
 
   @Override

--- a/eventbus-core/src/test/java/eu/tripledframework/eventbus/domain/asynchronous/AsynchronousEventBusTest.java
+++ b/eventbus-core/src/test/java/eu/tripledframework/eventbus/domain/asynchronous/AsynchronousEventBusTest.java
@@ -14,7 +14,6 @@ import eu.tripledframework.eventbus.command.HelloCommand;
 import eu.tripledframework.eventbus.command.ValidatingCommand;
 import eu.tripledframework.eventbus.domain.EventBusInterceptor;
 import eu.tripledframework.eventbus.domain.EventPublisher;
-import eu.tripledframework.eventbus.domain.callback.FutureEventCallback;
 import eu.tripledframework.eventbus.domain.interceptor.TestValidator;
 import eu.tripledframework.eventbus.domain.interceptor.ValidatingEventBusInterceptor;
 import eu.tripledframework.eventbus.handler.TestEventHandler;
@@ -59,11 +58,10 @@ public class AsynchronousEventBusTest {
     AsynchronousEventBus defaultPublisher = new AsynchronousEventBus();
     TestEventHandler eventHandler = new TestEventHandler();
     defaultPublisher.subscribe(eventHandler);
-    Future<Void> future = FutureEventCallback.forType(Void.class);
     HelloCommand command = new HelloCommand("domenique");
 
     // when
-    defaultPublisher.publish(command, future);
+    Future<Void> future = defaultPublisher.publish(command);
     future.get();
 
     // then
@@ -75,10 +73,9 @@ public class AsynchronousEventBusTest {
   public void whenGivenAValidCommand_shouldBeExecutedAsynchronous() throws Exception {
     // given
     HelloCommand command = new HelloCommand("Domenique");
-    Future<Void> future = FutureEventCallback.forType(Void.class);
 
     // when
-    asynchronousDispatcher.publish(command, future);
+    Future<Void> future = asynchronousDispatcher.publish(command);
     future.get();
 
     // then
@@ -90,10 +87,9 @@ public class AsynchronousEventBusTest {
   public void whenGivenAValidCommandAndFutureCallback_waitForExecutionToFinish() throws Exception {
     // given
     HelloCommand command = new HelloCommand("Domenique");
-    Future<Void> future = FutureEventCallback.forType(Void.class);
 
     // when
-    asynchronousDispatcher.publish(command, future);
+    Future<Void> future = asynchronousDispatcher.publish(command);
     future.get();
 
     // then
@@ -105,12 +101,11 @@ public class AsynchronousEventBusTest {
   @Test
   public void whenUsingADispatcherWithValidator_validationShouldBeDoneAsynchronous() throws Exception {
     // given
-    Future<Void> future = FutureEventCallback.forType(Void.class);
     ValidatingCommand command = new ValidatingCommand("should pass");
     validator.shouldFailNextCall(false);
 
     // when
-    dispatcherWithValidation.publish(command, future);
+    Future<Void> future = dispatcherWithValidation.publish(command);
     future.get();
 
     // then

--- a/eventbus-core/src/test/java/eu/tripledframework/eventbus/domain/synchronous/SynchronousEventBusTest.java
+++ b/eventbus-core/src/test/java/eu/tripledframework/eventbus/domain/synchronous/SynchronousEventBusTest.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
@@ -25,7 +24,6 @@ import eu.tripledframework.eventbus.domain.EventCallback;
 import eu.tripledframework.eventbus.domain.EventPublisher;
 import eu.tripledframework.eventbus.domain.EventSubscriber;
 import eu.tripledframework.eventbus.domain.callback.ExceptionThrowingEventCallback;
-import eu.tripledframework.eventbus.domain.callback.FutureEventCallback;
 import eu.tripledframework.eventbus.domain.dispatcher.EventHandlerNotFoundException;
 import eu.tripledframework.eventbus.domain.interceptor.CommandValidationException;
 import eu.tripledframework.eventbus.domain.interceptor.LoggingEventBusInterceptor;
@@ -151,18 +149,7 @@ public class SynchronousEventBusTest {
     FailingCommand command = new FailingCommand();
 
     // when
-    eventPublisher.publish(command);
-
-    // then --> exception
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void whenGivenACommandAndAWrongFuture_exceptionShouldBeThrown() throws Exception {
-    // given
-    HelloCommand command = new HelloCommand("Domenique");
-
-    // when
-    eventPublisher.publish(command, new CompletableFuture<>());
+    eventPublisher.publish(command, new ExceptionThrowingEventCallback<>());
 
     // then --> exception
   }
@@ -210,11 +197,10 @@ public class SynchronousEventBusTest {
   @Test
   public void whenGivenACommandWhichFails_shouldFail() throws Exception {
     // given
-    Future<Void> future = FutureEventCallback.forType(Void.class);
     FailingCommand command = new FailingCommand();
 
     // when
-    eventPublisher.publish(command, future);
+    Future<Void> future = eventPublisher.publish(command);
 
     try {
       future.get();
@@ -228,11 +214,10 @@ public class SynchronousEventBusTest {
   @Test
   public void whenGivenACommandWhichFailsWithACheckedExceptionUsingAFuture_shouldFail() throws Exception {
     // given
-    Future<Void> future = FutureEventCallback.forType(Void.class);
     FailingCommandWithCheckedException command = new FailingCommandWithCheckedException();
 
     // when
-    eventPublisher.publish(command, future);
+    Future<Void> future = eventPublisher.publish(command);
 
     try {
       future.get();

--- a/tripledframework-demo/src/main/java/eu/tripledframework/demo/presentation/HelloController.java
+++ b/tripledframework-demo/src/main/java/eu/tripledframework/demo/presentation/HelloController.java
@@ -1,17 +1,17 @@
 package eu.tripledframework.demo.presentation;
 
-import eu.tripledframework.demo.application.HelloCommand;
-import eu.tripledframework.demo.application.HelloResponse;
-import eu.tripledframework.eventbus.domain.EventPublisher;
-import eu.tripledframework.eventbus.domain.callback.FutureEventCallback;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import eu.tripledframework.demo.application.HelloCommand;
+import eu.tripledframework.demo.application.HelloResponse;
+import eu.tripledframework.eventbus.domain.EventPublisher;
 
 @RestController
 public class HelloController {
@@ -21,11 +21,8 @@ public class HelloController {
 
   @RequestMapping(value = "/hello/{name}", method = RequestMethod.GET)
   public HelloResponse sayHi(@PathVariable String name) throws ExecutionException, InterruptedException {
-    Future<HelloResponse> future = FutureEventCallback.forType(HelloResponse.class);
-    eventPublisher.publish(new HelloCommand(name), future);
+    Future<HelloResponse> future = eventPublisher.publish(new HelloCommand(name));
 
-    HelloResponse helloResponse = future.get();
-
-    return helloResponse;
+    return future.get();
   }
 }


### PR DESCRIPTION
Inspireded by a pull request from @krishofmans.

The EventBus should be responsible for creating a Future object when
calling the publish method. this implies that the client should not have
to bother to create a FutureEventCallback.

This implies that when calling `eventbus.publish(command)` without doing
anything with the returned future object, potential exceptions could be swallowed.
